### PR TITLE
Changed aptng plugin and check to support Ubuntu Hosts

### DIFF
--- a/aptng/checks/apt
+++ b/aptng/checks/apt
@@ -52,16 +52,28 @@ def check_apt(item, params, info):
 
     # Parse the agent output
     mod_time     = int(info[0][0])
-    deb_release  = info[1][0]
+    distribution = info[1][0]
+    dist_release  = info[2][0]
+
+    # Modify Repository Severity for Ubuntu Dist
+    if distribution == "Ubuntu":
+        ub_update = dist_release + "-updates"
+        apt_repository_severity[ub_update] = 2
 
     # If there are upgrades available parse them.
-    if len(info) > 2:
-        packages  = info[2:]
+    if len(info) > 3:
+        packages  = info[3:]
 
         for package in packages:
             name   = package[0]
+            # extract Ubuntu source info
+            # agent format: Ubuntu:12.04/precise-updates
+            if distribution == "Ubuntu":
+                source = package[1].split('/')[1]
+            # extract Debian source info
             # agent format: Debian-Security:6.0/stable
-            source = package[1].split(' ')[0].split(':')[0]
+            else:
+                source = package[1].split(' ')[0].split(':')[0]
 
             # Determine the severity of the situation :-)
             if source in apt_repository_severity:

--- a/aptng/checks/apt
+++ b/aptng/checks/apt
@@ -90,6 +90,10 @@ def check_apt(item, params, info):
     for source in apt_upgrades:
         msg += "%s/%s [%s] " % (source, len(apt_upgrades[source]), ",".join(apt_upgrades[source]))
 
+    # Inform user if there are no pending updates
+    if msg == "":
+        msg += "No pending updates found"
+
     # Determine apt cache age
     if mod_time > apt_cache_max_age:
         level = 1

--- a/aptng/plugins/apt
+++ b/aptng/plugins/apt
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 if [[ -e /etc/debian_version && `which apt-get` ]] &>/dev/null ; then
+    if [[ -e /etc/lsb-release ]] ; then
+        dist=`grep DISTRIB_ID /etc/lsb-release | awk -F = '{print $2}'`
+        release=`grep DISTRIB_CODENAME /etc/lsb-release | awk -F = '{print $2}'`
+    else
+        dist="Debian"
+        release=`cat /etc/debian_version`
+    fi
     cache_time_ref=/var/cache/apt/pkgcache.bin
     delta=0
 
@@ -22,6 +29,7 @@ if [[ -e /etc/debian_version && `which apt-get` ]] &>/dev/null ; then
 
     echo "<<<apt>>>"
     echo $delta
-    cat /etc/debian_version
+    echo $dist
+    echo $release
     waitmax 25 /usr/bin/apt-get -o Debug::NoLocking=yes -s dist-upgrade -y | awk '/^Inst/ { print $2 " " $5}' || echo "timeout_apt_get Debian-Security:X.X/DUMMY)"
 fi


### PR DESCRIPTION
Hi,
thanks for this great plugin! Just what we need here.

I just had a little problem when monitoring Ubuntu hosts: Updates are being marked warning even if they are security updates (e.g. from repo precise-updates) when they should be marked critical.

I've made some changes to the aptng-plugin to send info about the linux distribution AND release and modified the check to use that info when calculating the criticality.

Also added an informational update when no updates are found - the status page looks nicer that way.